### PR TITLE
Add achievements screen and badge state display

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,11 +17,13 @@
         tools:targetApi="31">
 
         <activity android:name=".InstructionsActivity" />
+
         <activity
             android:name=".QuizActivity"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
+
         <activity
-            android:name=".ResultActivity"
+            android:name=".AchievementsActivity"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
 
         <activity

--- a/app/src/main/java/com/example/quizzy/AchievementsActivity.java
+++ b/app/src/main/java/com/example/quizzy/AchievementsActivity.java
@@ -1,0 +1,113 @@
+package com.example.quizzy;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.util.List;
+
+public class AchievementsActivity extends AppCompatActivity {
+
+    private LinearLayout achievementsContainer;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_achievements);
+
+        achievementsContainer = findViewById(R.id.achievementsContainer);
+
+        int userId = 1;
+        List<Badges> badges = QuizRepository.getUserBadges(userId);
+
+        showBadges(badges);
+    }
+
+    private void showBadges(List<Badges> badges) {
+        achievementsContainer.removeAllViews();
+
+        if (badges == null || badges.isEmpty()) {
+            TextView empty = new TextView(this);
+            empty.setText("No badges available.");
+            empty.setTextSize(18f);
+            empty.setTextColor(Color.parseColor("#6E6257"));
+            empty.setGravity(Gravity.CENTER);
+            empty.setPadding(0, 80, 0, 0);
+            achievementsContainer.addView(empty);
+            return;
+        }
+
+        int maxToShow = Math.min(badges.size(), 10);
+
+        for (int i = 0; i < maxToShow; i++) {
+            Badges badge = badges.get(i);
+            boolean unlocked = badge.isUnlocked();
+
+            LinearLayout row = new LinearLayout(this);
+            row.setOrientation(LinearLayout.HORIZONTAL);
+            row.setGravity(Gravity.CENTER_VERTICAL);
+            row.setPadding(0, 18, 0, 18);
+            row.setAlpha(unlocked ? 1f : 0.45f);
+
+            LinearLayout textLayout = new LinearLayout(this);
+            textLayout.setOrientation(LinearLayout.VERTICAL);
+
+            LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(
+                    0,
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    1f
+            );
+            textLayout.setLayoutParams(textParams);
+
+            TextView title = new TextView(this);
+            title.setText(badge.getName());
+            title.setTextSize(18f);
+            title.setTypeface(null, android.graphics.Typeface.BOLD);
+            title.setTextColor(unlocked
+                    ? Color.parseColor("#3E3126")
+                    : Color.parseColor("#9E9E9E"));
+
+            TextView description = new TextView(this);
+            description.setText(badge.getDescription());
+            description.setTextSize(14f);
+            description.setTextColor(unlocked
+                    ? Color.parseColor("#6E6257")
+                    : Color.parseColor("#BDBDBD"));
+
+            TextView status = new TextView(this);
+            status.setText(unlocked ? "Unlocked" : "Locked");
+            status.setTextSize(12f);
+            status.setPadding(0, 6, 0, 0);
+            status.setTextColor(unlocked
+                    ? Color.parseColor("#2E7D32")
+                    : Color.parseColor("#9E9E9E"));
+
+            TextView icon = new TextView(this);
+            icon.setText(unlocked ? "🏆" : "🔒");
+            icon.setTextSize(22f);
+            icon.setPadding(16, 0, 0, 0);
+
+            textLayout.addView(title);
+            textLayout.addView(description);
+            textLayout.addView(status);
+
+            row.addView(textLayout);
+            row.addView(icon);
+
+            achievementsContainer.addView(row);
+
+            View divider = new View(this);
+            divider.setLayoutParams(new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    1
+            ));
+            divider.setBackgroundColor(Color.parseColor("#DDDDDD"));
+
+            achievementsContainer.addView(divider);
+        }
+    }
+}

--- a/app/src/main/java/com/example/quizzy/BadgeCatalog.java
+++ b/app/src/main/java/com/example/quizzy/BadgeCatalog.java
@@ -7,16 +7,16 @@ public class BadgeCatalog {
     public static List<Badges> getAllBadges() {
         List<Badges> badges = new ArrayList<>();
 
-        badges.add(new Badges(1, "First Quiz", "Complete your first quiz."));
-        badges.add(new Badges(2, "Perfect Score", "Score 100% on a quiz."));
-        badges.add(new Badges(3, "High Achiever", "Score 80% or higher on a quiz."));
-        badges.add(new Badges(4, "Quiz Explorer", "Try different quiz levels."));
-        badges.add(new Badges(5, "Dedicated Learner", "Complete 5 quizzes."));
-        badges.add(new Badges(6, "Math Rookie", "Complete 3 math quizzes."));
-        badges.add(new Badges(7, "Math Master", "Complete 10 math quizzes."));
-        badges.add(new Badges(8, "On a Roll", "Answer 3 questions correctly in a row."));
-        badges.add(new Badges(9, "Getting Better", "Improve your score from a previous quiz."));
-        badges.add(new Badges(10, "Badge Collector", "Earn 5 badges."));
+        badges.add(new Badges(1, "First Quiz", "Complete your first quiz", true));
+        badges.add(new Badges(2, "Perfect Score", "Score 100% on a quiz", false));
+        badges.add(new Badges(3, "High Achiever", "Score 80% or higher", true));
+        badges.add(new Badges(4, "Quiz Explorer", "Try different quiz levels", false));
+        badges.add(new Badges(5, "Dedicated Learner", "Complete 10 quizzes", false));
+        badges.add(new Badges(6, "Math Rookie", "Complete 3 math quizzes", true));
+        badges.add(new Badges(7, "Math Master", "Complete 10 math quizzes", false));
+        badges.add(new Badges(8, "On a Roll", "Answer 3 questions correctly in a row", false));
+        badges.add(new Badges(9, "Getting Better", "Improve your score", true));
+        badges.add(new Badges(10, "Badge Collector", "Collect 5 badges", false));
 
         return badges;
     }

--- a/app/src/main/java/com/example/quizzy/Badges.java
+++ b/app/src/main/java/com/example/quizzy/Badges.java
@@ -1,17 +1,32 @@
 package com.example.quizzy;
 
 public class Badges {
+
     private int id;
     private String name;
     private String description;
+    private boolean unlocked;
 
-    public Badges(int id, String name, String description) {
+    public Badges(int id, String name, String description, boolean unlocked) {
         this.id = id;
         this.name = name;
         this.description = description;
+        this.unlocked = unlocked;
     }
 
-    public int getId() { return id; }
-    public String getName() { return name; }
-    public String getDescription() { return description; }
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isUnlocked() {
+        return unlocked;
+    }
 }

--- a/app/src/main/java/com/example/quizzy/MainActivity.kt
+++ b/app/src/main/java/com/example/quizzy/MainActivity.kt
@@ -55,6 +55,7 @@ class MainActivity : ComponentActivity() {
                                 "Home", "Dashboard" -> DashboardScreen(
                                     onStartQuiz = { currentScreen = "QuizSelection" }
                                 )
+
                                 "QuizSelection" -> QuizSelectionScreen(
                                     onGradeSelected = { gradeLevel, gradeName ->
                                         val intent = Intent(this@MainActivity, InstructionsActivity::class.java).apply {
@@ -64,7 +65,14 @@ class MainActivity : ComponentActivity() {
                                         startActivity(intent)
                                     }
                                 )
-                                "Achievements" -> PlaceholderScreen("Achievements")
+
+                                "Achievements" -> {
+                                    LaunchedEffect(Unit) {
+                                        startActivity(Intent(this@MainActivity, AchievementsActivity::class.java))
+                                        currentScreen = "Home"
+                                    }
+                                }
+
                                 "Guardian" -> PlaceholderScreen("Guardian Dashboard")
                                 "Settings" -> PlaceholderScreen("Settings")
                             }

--- a/app/src/main/java/com/example/quizzy/QuizRepository.java
+++ b/app/src/main/java/com/example/quizzy/QuizRepository.java
@@ -4,13 +4,22 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class QuizRepository {
-    public static List<Question> currentQuizQuestions = new ArrayList<>();
-    public static List<Badges> getUserBadges(int userId) {
 
+    public static List<Question> currentQuizQuestions = new ArrayList<>();
+
+    public static List<Badges> getUserBadges(int userId) {
         List<Badges> badges = new ArrayList<>();
-        badges.add(new Badges(1, "Beginner", "Completed first quiz"));
-        badges.add(new Badges(2, "Intermediate", "Completed 5 quizzes"));
-        badges.add(new Badges(3, "Pro", "Scored 100%"));
+
+        badges.add(new Badges(1, "First Quiz", "Complete your first quiz", true));
+        badges.add(new Badges(2, "Perfect Score", "Score 100% on a quiz", false));
+        badges.add(new Badges(3, "High Achiever", "Score 80% or higher", true));
+        badges.add(new Badges(4, "Quiz Explorer", "Try different quiz levels", false));
+        badges.add(new Badges(5, "Dedicated Learner", "Complete 10 quizzes", false));
+        badges.add(new Badges(6, "Math Rookie", "Complete 3 math quizzes", true));
+        badges.add(new Badges(7, "Math Master", "Complete 10 math quizzes", false));
+        badges.add(new Badges(8, "On a Roll", "Answer 3 questions correctly in a row", false));
+        badges.add(new Badges(9, "Getting Better", "Improve your score", true));
+        badges.add(new Badges(10, "Badge Collector", "Collect 5 badges", false));
 
         return badges;
     }

--- a/app/src/main/res/layout/activity_achievements.xml
+++ b/app/src/main/res/layout/activity_achievements.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#F7F4EF">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/tvBadgesTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Badges"
+            android:textSize="30sp"
+            android:textStyle="bold"
+            android:textColor="#3E3126"
+            android:layout_marginBottom="16dp" />
+
+        <LinearLayout
+            android:id="@+id/achievementsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
This PR adds the Achievements screen accessible from the dashboard.

Changes made:
- Added AchievementsActivity
- Added achievements screen layout
- Added support for displaying up to 10 badges
- Added locked/unlocked visual differentiation for badges
- Updated badge model to include unlocked state
- Updated repository badge data for badge state display
- Connected Achievements screen from the dashboard flow

No filter is included in this iteration.